### PR TITLE
Removed passing in session

### DIFF
--- a/cunyfirstapi/cunyfirstapi.py
+++ b/cunyfirstapi/cunyfirstapi.py
@@ -103,7 +103,10 @@ class CUNYFirstAPI():
             new_session = requests.Session()
             self._session = PersistentSession(self._username, self._password)
         else:
-            self._session =  new_session.login(new_session._username, new_session._password)
+            self._session =  new_session.login(
+                new_session._username, 
+                new_session._password
+            )
 
     def logout(self):
         try:

--- a/cunyfirstapi/cunyfirstapi.py
+++ b/cunyfirstapi/cunyfirstapi.py
@@ -93,15 +93,15 @@ class PersistentSession:
 
 class CUNYFirstAPI():
 
-    def __init__(self, new_session = None):
-        if new_session is None:
-            new_session = requests.Session()
-        self._session = PersistentSession(new_session)
+    def __init__(self, username=None, password=None):
+        self._username = username
+        self._password = password
+        self._session = PersistentSession(self._username, self._password)
 
     def restart_session(self):
-        if new_session is None:
+        if self._session is None:
             new_session = requests.Session()
-            self._session = PersistentSession(new_session)
+            self._session = PersistentSession(self._username, self._password)
         else:
             self._session =  new_session.login(new_session._username, new_session._password)
 
@@ -114,9 +114,15 @@ class CUNYFirstAPI():
         except BaseException:
             return False 
 
-    def login(self, username, password):
+    def set_password(self, password):
+        self._password = password
+
+    def set_username(self, username):
+        self._username = username
+
+    def login(self):
         # Pass through to session class
-        self._session.login(username, password)
+        self._session.login(self._username, self._password)
 
     def to_login(self):
         return self._session.get(constants.CUNY_FIRST_HOME_URL)

--- a/cunyfirstapi/cunyfirstapi.py
+++ b/cunyfirstapi/cunyfirstapi.py
@@ -1,3 +1,14 @@
+###***********************************###
+'''
+Grade Notifier
+File: cunyfirstaapi.py
+Core Maintainers: Ehud Adler, Akiva Sherman, 
+Yehuda Moskovits
+Copyright: Copyright 2019, Ehud Adler
+License: MIT
+'''
+###***********************************###
+
 from os import sys, path
 from lxml import html
 from os.path import join, dirname
@@ -5,21 +16,10 @@ import requests
 import re
 from . import constants
 
-
-__author__ = "Ehud Adler"
-__copyright__ = "Copyright 2018, CUNY Suite"
-__license__ = "MIT"
-__version__ = "1.0.0"
-__maintainer__ = "Ehud Adler & Akiva Sherman"
-__email__ = "self@ehudadler.com"
-__status__ = "Production"
-
 '''
 The Cuny Navigator makes moving around the cunyFirst website
 alot easier.
 '''
-
-
 class PersistentSession:
 
     def __init__(self, username=None, password=None):
@@ -123,6 +123,12 @@ class CUNYFirstAPI():
     def set_username(self, username):
         self._username = username
 
+    def get_current_session(self):
+        return self._session
+
+    def is_logged_in():
+        return self._session.is_logged_in()
+        
     def login(self):
         # Pass through to session class
         self._session.login(self._username, self._password)

--- a/cunyfirstapi/cunyfirstapi.py
+++ b/cunyfirstapi/cunyfirstapi.py
@@ -2,7 +2,7 @@
 '''
 Grade Notifier
 File: cunyfirstaapi.py
-Core Maintainers: Ehud Adler, Akiva Sherman, 
+Core Maintainers: Ehud Adler, Akiva Sherman,
 Yehuda Moskovits
 Copyright: Copyright 2019, Ehud Adler
 License: MIT
@@ -126,9 +126,9 @@ class CUNYFirstAPI():
     def get_current_session(self):
         return self._session
 
-    def is_logged_in():
+    def is_logged_in(self):
         return self._session.is_logged_in()
-        
+
     def login(self):
         # Pass through to session class
         self._session.login(self._username, self._password)


### PR DESCRIPTION
No more passing in session to the CunyFirstAPI, makes no sense. 

If your using the API it will handle the session for you. 

If your looking to make use of the current session, request it. Right now you can use ._session but well make a getter, get_current_session. 

This should make a lot more sense and allow for more understanding between the dev and the API