### PR TITLE
Fix things #trivial

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Okay so you know what we're looking to do. Here's how you can help:
 3. git clone ....... from your fork
 
 #### Installing the package locally for testing
-To install and run this package locally, clone the repository and inside the root directory run `python3 setup.py install --user`
+To install and run this package locally, clone the repository and inside the root directory run `python3 -m pip install --user -e .`
 
 
 ### Code of Conduct

--- a/cunyfirstapi/__init__.py
+++ b/cunyfirstapi/__init__.py
@@ -1,0 +1,3 @@
+name = "cunyfirstapi"
+from .cunyfirstapi import *
+from . import constants


### PR DESCRIPTION
Undo changes to local installation instructions so it actually works again
Put the init file back so the namespaces work again